### PR TITLE
Issue with avalonia shell after opening context menu

### DIFF
--- a/Avalonia.Boilerplate/Avalonia.Boilerplate/Avalonia.Boilerplate.csproj
+++ b/Avalonia.Boilerplate/Avalonia.Boilerplate/Avalonia.Boilerplate.csproj
@@ -17,9 +17,9 @@
     </AvaloniaXaml>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0" />
+    <PackageReference Include="Avalonia" Version="0.10.6" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.6" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.6" />
    </ItemGroup>
   <ItemGroup>
     <Compile Update="App.xaml.cs">

--- a/Avalonia.Boilerplate/Avalonia.Boilerplate/Avalonia.Boilerplate.csproj
+++ b/Avalonia.Boilerplate/Avalonia.Boilerplate/Avalonia.Boilerplate.csproj
@@ -17,9 +17,9 @@
     </AvaloniaXaml>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.6" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.6" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.6" />
+    <PackageReference Include="Avalonia" Version="0.10.999-cibuild0014911-beta" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.999-cibuild0014911-beta" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.999-cibuild0014911-beta" />
    </ItemGroup>
   <ItemGroup>
     <Compile Update="App.xaml.cs">

--- a/Avalonia.Boilerplate/Avalonia.Boilerplate/MainWindow.xaml
+++ b/Avalonia.Boilerplate/Avalonia.Boilerplate/MainWindow.xaml
@@ -1,9 +1,5 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="Avalonia.Boilerplate.MainWindow"
-        Title="Avalonia.Boilerplate">
-    Welcome to Avalonia!
+        ExtendClientAreaToDecorationsHint="True">
 </Window>

--- a/Avalonia.Boilerplate/Avalonia.Boilerplate/MainWindow.xaml.cs
+++ b/Avalonia.Boilerplate/Avalonia.Boilerplate/MainWindow.xaml.cs
@@ -1,16 +1,40 @@
-using Avalonia;
+using System.Collections;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 
 namespace Avalonia.Boilerplate {
     public class MainWindow : Window {
+        private ContextMenu contextMenu;
+
         public MainWindow() {
             InitializeComponent();
 #if DEBUG
             this.AttachDevTools();
 #endif
+            
+            AddHandler(PointerReleasedEvent, MouseUpHandler, handledEventsToo: true);
         }
 
+        private void MouseUpHandler(object? sender, PointerReleasedEventArgs e)
+        {
+            contextMenu?.Close();
+            contextMenu = null;
+            
+            if (e.InitialPressMouseButton == MouseButton.Left)
+            {
+                return;
+            } 
+            
+            contextMenu = new ContextMenu();
+            contextMenu.Items = new ArrayList
+            {
+                new ItemsControl() { Name = "entry 1" }
+            };
+
+            contextMenu.Open(this);
+        }
+        
         private void InitializeComponent() {
             AvaloniaXamlLoader.Load(this);
         }


### PR DESCRIPTION
There is an issue with the shell after opening a context menu and resize the window if the property **ExtendClientAreaToDecorationsHint** on the MainWindow.xaml is set to **True**.

How to reproduce:
1. Open a context menu
2. Resize window
3. Try move move window around (but can't)

Important findings:
- Reopening the context menu and closing it allows us to move the window around (until the next resize)
- If the context menu is never opened, this issue never occurs

Created an issue in Avalonia page https://github.com/AvaloniaUI/Avalonia/issues/6221